### PR TITLE
FE from domain_specifics.yaml

### DIFF
--- a/ssg/domain_specifics.yaml
+++ b/ssg/domain_specifics.yaml
@@ -1,90 +1,137 @@
 ---
 domain:
-  poff.ee: poff
-  justfilm.ee: justfilm
-  kinoff.poff.ee: kinoff
-  industry.poff.ee: industry
-  shorts.poff.ee: shorts
-  hoff.ee: hoff
-  kumu.poff.ee: kumu
-  tartuff.ee: tartuff
-  oyafond.ee: bruno
-  filmikool.poff.ee: filmikool
+    poff.ee: poff
+    justfilm.ee: justfilm
+    kinoff.poff.ee: kinoff
+    industry.poff.ee: industry
+    shorts.poff.ee: shorts
+    hoff.ee: hoff
+    kumu.poff.ee: kumu
+    tartuff.ee: tartuff
+    oyafond.ee: bruno
+    filmikool.poff.ee: filmikool
+
+domains_show_cassetes_wo_screenings:
+    - poff.ee
+    - hoff.ee
+
+cassettes_festival_editions:
+    poff.ee:
+        - 7
+    justfilm.ee:
+        - 3
+    kinoff.poff.ee:
+        - 4
+    industry.poff.ee:
+        - 0
+    shorts.poff.ee:
+        - 2
+    hoff.ee:
+        - 5
+    kumu.poff.ee:
+        - 0
+    tartuff.ee:
+        - 0
+    oyafond.ee:
+        - 0
+    filmikool.poff.ee:
+        - 0
+
+programmes_festival_editions:
+    poff.ee:
+        - 7
+    justfilm.ee:
+        - 3
+    kinoff.poff.ee:
+        - 4
+    industry.poff.ee:
+        - 0
+    shorts.poff.ee:
+        - 2
+    hoff.ee:
+        - 5
+    kumu.poff.ee:
+        - 0
+    tartuff.ee:
+        - 0
+    oyafond.ee:
+        - 0
+    filmikool.poff.ee:
+        - 0
 
 article:
-  poff.ee: POFFiArticle
-  justfilm.ee: JustFilmiArticle
-  kinoff.poff.ee: KinoffiArticle
-  industry.poff.ee: IndustryArticle
-  shorts.poff.ee: ShortsiArticle
-  hoff.ee: HOFFiArticle
-  kumu.poff.ee: KumuArticle
-  tartuff.ee: TartuffiArticle
-  oyafond.ee: BrunoArticle
-  filmikool.poff.ee: FilmikooliArticle
+    poff.ee: POFFiArticle
+    justfilm.ee: JustFilmiArticle
+    kinoff.poff.ee: KinoffiArticle
+    industry.poff.ee: IndustryArticle
+    shorts.poff.ee: ShortsiArticle
+    hoff.ee: HOFFiArticle
+    kumu.poff.ee: KumuArticle
+    tartuff.ee: TartuffiArticle
+    oyafond.ee: BrunoArticle
+    filmikool.poff.ee: FilmikooliArticle
 
 footer:
-  poff.ee: POFFiFooter
-  justfilm.ee: JustFilmFooter
-  kinoff.poff.ee: KinoffiFooter
-  industry.poff.ee: IndustryFooter
-  shorts.poff.ee: ShortsiFooter
-  hoff.ee: HOFFiFooter
-  kumu.poff.ee: KumuFooter
-  tartuff.ee: TartuffiFooter
-  oyafond.ee: BrunoFooter
-  filmikool.poff.ee: FilmikooliFooter
+    poff.ee: POFFiFooter
+    justfilm.ee: JustFilmFooter
+    kinoff.poff.ee: KinoffiFooter
+    industry.poff.ee: IndustryFooter
+    shorts.poff.ee: ShortsiFooter
+    hoff.ee: HOFFiFooter
+    kumu.poff.ee: KumuFooter
+    tartuff.ee: TartuffiFooter
+    oyafond.ee: BrunoFooter
+    filmikool.poff.ee: FilmikooliFooter
 
 locales:
-  poff.ee:
-  - et
-  - en
-  - ru
-  justfilm.ee:
-  - et
-  - en
-  - ru
-  kinoff.poff.ee:
-  - et
-  - en
-  - ru
-  industry.poff.ee:
-  - en
-  shorts.poff.ee:
-  - et
-  - en
-  hoff.ee:
-  - et
-  - en
-  kumu.poff.ee:
-  - et
-  - en
-  - ru
-  tartuff.ee:
-  - et
-  - en
-  - ru
-  oyafond.ee:
-  - et
-  - en
-  - ru
-  filmikool.poff.ee:
-  - et
-  - en
-  - ru
-
+    poff.ee:
+        - et
+        - en
+        - ru
+    justfilm.ee:
+        - et
+        - en
+        - ru
+    kinoff.poff.ee:
+        - et
+        - en
+        - ru
+    industry.poff.ee:
+        - en
+    shorts.poff.ee:
+        - et
+        - en
+    hoff.ee:
+        - et
+        - en
+    kumu.poff.ee:
+        - et
+        - en
+        - ru
+    tartuff.ee:
+        - et
+        - en
+        - ru
+    oyafond.ee:
+        - et
+        - en
+        - ru
+    filmikool.poff.ee:
+        - et
+        - en
+        - ru
 
 defaultLocale:
-  poff.ee: et
-  justfilm.ee: et
-  kinoff.poff.ee: et
-  industry.poff.ee: en
-  shorts.poff.ee: et
-  hoff.ee: et
-  kumu.poff.ee: et
-  tartuff.ee: et
-  oyafond.ee: et
-  filmikool.poff.ee: et
+    poff.ee: et
+    justfilm.ee: et
+    kinoff.poff.ee: et
+    industry.poff.ee: en
+    shorts.poff.ee: et
+    hoff.ee: et
+    kumu.poff.ee: et
+    tartuff.ee: et
+    oyafond.ee: et
+    filmikool.poff.ee: et
 
 vialogUrls:
     et:
@@ -107,25 +154,25 @@ vialogUrls:
         - "https://hoff.ee/ru/film/"
 
 pageURLs:
-  poff.ee: "https://poff.ee/"
-  justfilm.ee: "https://justfilm.ee/"
-  kinoff.poff.ee: "https://kinoff.poff.ee/"
-  industry.poff.ee: "https://industry.poff.ee/"
-  shorts.poff.ee: "http://shorts.poff.ee/"
-  hoff.ee: "https://hoff.ee/"
-  kumu.poff.ee: "https://kumu.poff.ee/"
-  tartuff.ee: "https://tartuff.ee/"
-  oyafond.ee: "https://oyafond.ee/"
-  filmikool.poff.ee: "https://filmikool.poff.ee/"
+    poff.ee: "https://poff.ee/"
+    justfilm.ee: "https://justfilm.ee/"
+    kinoff.poff.ee: "https://kinoff.poff.ee/"
+    industry.poff.ee: "https://industry.poff.ee/"
+    shorts.poff.ee: "http://shorts.poff.ee/"
+    hoff.ee: "https://hoff.ee/"
+    kumu.poff.ee: "https://kumu.poff.ee/"
+    tartuff.ee: "https://tartuff.ee/"
+    oyafond.ee: "https://oyafond.ee/"
+    filmikool.poff.ee: "https://filmikool.poff.ee/"
 
 stagingURLs:
-  poff.ee: "https://staging.poff.inscaping.eu/"
-  justfilm.ee: "https://staging.justfilm.inscaping.eu/"
-  kinoff.poff.ee: "https://staging.kinoff.inscaping.eu/"
-  industry.poff.ee: "https://staging.industry.inscaping.eu/"
-  shorts.poff.ee: "https://staging.shorts.inscaping.eu/"
-  # hoff.ee: "https://staging.hoff.inscaping.eu/"
-  # kumu.poff.ee: https://kumu.poff.ee/
-  # tartuff.ee: https://tartuff.ee/
-  # oyafond.ee: https://oyafond.ee/
-  # filmikool.poff.ee: https://filmikool.poff.ee/
+    poff.ee: "https://staging.poff.inscaping.eu/"
+    justfilm.ee: "https://staging.justfilm.inscaping.eu/"
+    kinoff.poff.ee: "https://staging.kinoff.inscaping.eu/"
+    industry.poff.ee: "https://staging.industry.inscaping.eu/"
+    shorts.poff.ee: "https://staging.shorts.inscaping.eu/"
+    # hoff.ee: "https://staging.hoff.inscaping.eu/"
+    # kumu.poff.ee: https://kumu.poff.ee/
+    # tartuff.ee: https://tartuff.ee/
+    # oyafond.ee: https://oyafond.ee/
+    # filmikool.poff.ee: https://filmikool.poff.ee/

--- a/ssg/helpers/fetch_cassettes_from_yaml.js
+++ b/ssg/helpers/fetch_cassettes_from_yaml.js
@@ -21,14 +21,15 @@ const strapiDataPersonPath = path.join(strapiDataDirPath, 'Person.yaml')
 const STRAPIDATA_PERSONS = yaml.safeLoad(fs.readFileSync(strapiDataPersonPath, 'utf8'))
 const strapiDataProgrammePath = path.join(strapiDataDirPath, 'Programme.yaml')
 const STRAPIDATA_PROGRAMMES = yaml.safeLoad(fs.readFileSync(strapiDataProgrammePath, 'utf8'))
-const strapiDataFEPath = path.join(strapiDataDirPath, 'FestivalEdition.yaml')
-const STRAPIDATA_FE = yaml.safeLoad(fs.readFileSync(strapiDataFEPath, 'utf8'))
+// const strapiDataFEPath = path.join(strapiDataDirPath, 'FestivalEdition.yaml')
+// const STRAPIDATA_FE = yaml.safeLoad(fs.readFileSync(strapiDataFEPath, 'utf8'))
 const strapiDataScreeningPath = path.join(strapiDataDirPath, 'Screening.yaml')
 const STRAPIDATA_SCREENINGS_YAML = yaml.safeLoad(fs.readFileSync(strapiDataScreeningPath, 'utf8'))
 const strapiDataCassettePath = path.join(strapiDataDirPath, 'Cassette.yaml')
 const STRAPIDATA_CASSETTES_YAML = yaml.safeLoad(fs.readFileSync(strapiDataCassettePath, 'utf8'))
 const whichScreeningTypesToFetch = []
 const DOMAIN = process.env['DOMAIN'] || 'poff.ee'
+const festival_editions = DOMAIN_SPECIFICS.cassettes_festival_editions[DOMAIN] || []
 
 // Kassettide limiit mida buildida
 const CASSETTELIMIT = parseInt(process.env['CASSETTELIMIT']) || 0
@@ -37,7 +38,7 @@ const CASSETTELIMIT = parseInt(process.env['CASSETTELIMIT']) || 0
 const CHECKPROGRAMMES = false
 
 // Domeenid mille puhul näidatakse ka filme millel ei ole screeningut
-const skipScreeningsCheckDomains = ['poff.ee', 'hoff.ee']
+const skipScreeningsCheckDomains = DOMAIN_SPECIFICS.domains_show_cassetes_wo_screenings
 
 // Teistel domeenidel, siia kõik Screening_types name mida soovitakse kasseti juurde lisada, VÄIKETÄHTEDES.
 if (!skipScreeningsCheckDomains.includes(DOMAIN))  {
@@ -250,13 +251,7 @@ if(CHECKPROGRAMMES) {
 } else if (!CHECKPROGRAMMES) { //  && DOMAIN !== 'poff.ee' commented out, unsure why set in first place
 
     let cassettesWithOutFestivalEditions = []
-    let festival_editions = []
-    // For PÖFF, fetch only online 2021 FE ID 7
-    if (DOMAIN !== 'poff.ee') {
-        festival_editions = STRAPIDATA_FE.map(edition => edition.id)
-    } else {
-        festival_editions = [7]
-    }
+
     var STRAPIDATA_CASSETTE = STRAPIDATA_CASSETTES.filter(cassette => {
         if (cassette.festival_editions && cassette.festival_editions.length) {
             let cassette_festival_editions_ids = cassette.festival_editions.map(edition => edition.id)

--- a/ssg/helpers/fetch_cassettes_from_yaml.js
+++ b/ssg/helpers/fetch_cassettes_from_yaml.js
@@ -38,7 +38,7 @@ const CASSETTELIMIT = parseInt(process.env['CASSETTELIMIT']) || 0
 const CHECKPROGRAMMES = false
 
 // Domeenid mille puhul näidatakse ka filme millel ei ole screeningut
-const skipScreeningsCheckDomains = DOMAIN_SPECIFICS.domains_show_cassetes_wo_screenings
+const skipScreeningsCheckDomains = DOMAIN_SPECIFICS.domains_show_cassetes_wo_screenings || []
 
 // Teistel domeenidel, siia kõik Screening_types name mida soovitakse kasseti juurde lisada, VÄIKETÄHTEDES.
 if (!skipScreeningsCheckDomains.includes(DOMAIN))  {

--- a/ssg/helpers/fetch_programmes_from_yaml.js
+++ b/ssg/helpers/fetch_programmes_from_yaml.js
@@ -3,6 +3,7 @@ const yaml = require('js-yaml');
 const path = require('path');
 const rueten = require('./rueten.js');
 
+const rootDir =  path.join(__dirname, '..')
 const sourceDir =  path.join(__dirname, '..', 'source');
 const fetchDir =  path.join(sourceDir, '_fetchdir');
 const fetchDataDir =  path.join(fetchDir, 'programmes');
@@ -11,7 +12,9 @@ const strapiDataProgrammePath = path.join(strapiDataDirPath, 'Programme.yaml')
 const STRAPIDATA_PROGRAMME = yaml.safeLoad(fs.readFileSync(strapiDataProgrammePath, 'utf8'))
 const strapiDataOrganisationPath = path.join(strapiDataDirPath, 'Organisation.yaml')
 const STRAPIDATA_ORGANISATIONS = yaml.safeLoad(fs.readFileSync(strapiDataOrganisationPath, 'utf8'))
-const DOMAIN = process.env['DOMAIN'] || 'poff.ee';
+const domainSpecificsPath = path.join(rootDir, 'domain_specifics.yaml')
+const DOMAIN_SPECIFICS = yaml.safeLoad(fs.readFileSync(domainSpecificsPath, 'utf8'))
+const DOMAIN = process.env['DOMAIN'] || 'hoff.ee';
 
 const languages = ['en', 'et', 'ru']
 const mapping = {
@@ -27,12 +30,25 @@ const mapping = {
     'oyafond.ee': 'bruno'
 }
 
+const festival_editions = DOMAIN_SPECIFICS.programmes_festival_editions[DOMAIN] || []
+
 for (const ix in languages) {
     const lang = languages[ix];
     console.log(`Fetching ${DOMAIN} programmes ${lang} data`);
 
+    // Filter out all programmes that do not have at least one FE defined
+    // under domain specifics programmes_festival_editions
+    var STRAPIDATA_PROGRAMMES = STRAPIDATA_PROGRAMME.filter(programmes => {
+        if (programmes.festival_editions && programmes.festival_editions.length) {
+            let programmes_festival_editions_ids = programmes.festival_editions.map(edition => edition.id)
+            return programmes_festival_editions_ids.filter(cfe_id => festival_editions.includes(cfe_id))[0] !== undefined
+        } else {
+            return false
+        }
+    })
+
     var allData = []
-    for (const ix in STRAPIDATA_PROGRAMME) {
+    for (const ix in STRAPIDATA_PROGRAMMES) {
 
         if (mapping[DOMAIN]) {
             var templateDomainName = mapping[DOMAIN];
@@ -40,7 +56,7 @@ for (const ix in languages) {
             console.log('ERROR! Missing domain name for assigning template.');
             continue;
         }
-        let element = JSON.parse(JSON.stringify(STRAPIDATA_PROGRAMME[ix]));
+        let element = JSON.parse(JSON.stringify(STRAPIDATA_PROGRAMMES[ix]));
         let dirSlug = element.slug_en || element.slug_et ? element.slug_en || element.slug_et : null ;
 
 


### PR DESCRIPTION
Kassettide ja programmide fetchimiseks saab määrata Festival Editionite ID-d iga domeeni juures failis **ssg\domain_specifics.yaml**
Vastavalt kassettidel **cassettes_festival_editions** ja programmidel **programmes_festival_editions**

Lisaks on nüüd samas failis määratletud ka **domeenid milledel soovime kuvada kassette millel puuduvad screeningud** (**domains_show_cassetes_wo_screenings**).

Resolves #89