### PR TITLE
Aliases for articles

### DIFF
--- a/ssg/helpers/fetch_article_type_from_yaml.js
+++ b/ssg/helpers/fetch_article_type_from_yaml.js
@@ -184,6 +184,14 @@ for (const lang of languages) {
                         if (element[key] === 'lemmikfilm') {
                             element.aliases = ['lemmikfilm', 'publikulemmik']
                         }
+                        // 2021 adding covid article aliases
+                        if (element[key] === 'koroonareeglid') {
+                            element.aliases = ['covid', 'koroonareeglid']
+                        }
+                        // 2021 adding Industry article aliases
+                        if (element[key] === 'music-meets-film-1') {
+                            element.aliases = ['about/music-meets-film']
+                        }
                     }
                 }
                 element.data = dataFrom;


### PR DESCRIPTION
Aliases for POFFi article https://poff.ee/artikkel/koroonareeglid/ :
poff.ee/covid
poff.ee/koroonareeglid

Alias for Industry article https://industry.poff.ee/about/music-meets-film/ :
industry.poff.ee/about/music-meets-film-1/