### PR TITLE
Filter industry persons by FE

### DIFF
--- a/ssg/docs/datamodel.yaml
+++ b/ssg/docs/datamodel.yaml
@@ -1035,7 +1035,7 @@ Film: &Film
         -   *Language
     subtitles: #(Component (repeatable))
         -   *Language
-    other_festivals: 
+    other_festivals:
         -   *Festival
     credentials: *Credentials
     presentedBy: *PresentedBy
@@ -1236,8 +1236,8 @@ IndustryPerson: &IndustryPerson
         - *IndustryPersonType
     lookingFor: (text)
     contactAtEvent: (text)
-    festival_editions: 
-        -   *FestivalEdition
+    festival_editions:
+        - *FestivalEdition
 
 IndustryArticle: &IndustryArticle
     _path: /industry-articles

--- a/ssg/helpers/fetch_industry_person_from_yaml.js
+++ b/ssg/helpers/fetch_industry_person_from_yaml.js
@@ -5,7 +5,11 @@ const rueten = require('./rueten.js');
 const {fetchModel} = require('./b_fetch.js')
 const replaceLinks = require('./replace_links.js')
 
-const sourceDir =  path.join(__dirname, '..', 'source');
+const rootDir =  path.join(__dirname, '..')
+const domainSpecificsPath = path.join(rootDir, 'domain_specifics.yaml')
+const DOMAIN_SPECIFICS = yaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
+const INDUSTRY_ACTIVE_FESTIVAL_EDITIONS = DOMAIN_SPECIFICS.active_industry_editions
+const sourceDir =  path.join(rootDir, 'source');
 const fetchDir =  path.join(sourceDir, '_fetchdir');
 const fetchDataDir =  path.join(fetchDir, 'industrypersons');
 const strapiDataPath = path.join(sourceDir, '_domainStrapidata', 'IndustryPerson.yaml');
@@ -43,7 +47,8 @@ if (DOMAIN !== 'industry.poff.ee') {
         }
     }
 
-    const STRAPIDATA_INDUSTRY_PERSONS = fetchModel(STRAPIDATA_INDUSTRY_PERSON, minimodel)
+    const STRAPIDATA_ALL_FE_INDUSTRY_PERSONS = fetchModel(STRAPIDATA_INDUSTRY_PERSON, minimodel)
+    const STRAPIDATA_INDUSTRY_PERSONS = STRAPIDATA_ALL_FE_INDUSTRY_PERSONS.filter(p => p.festival_editions && p.festival_editions.map(ed => ed.id).some(id => INDUSTRY_ACTIVE_FESTIVAL_EDITIONS.includes(id)))
 
     const rootDir =  path.join(__dirname, '..')
     const domainSpecificsPath = path.join(rootDir, 'domain_specifics.yaml')


### PR DESCRIPTION
Industry persons are now filtered by active_industry_editions listed in domain_specifics and affected pages (ex: /featured-persons) built accordingly including only people who have at least one festival_edition assigned and present in domain_specifics.active_industry_editions.
**Note:** Currently there are no industry_persons with festival_edition assigned in Strapi.

Resolves #371 