### PR TITLE
Build exclusions to domain specifics

### DIFF
--- a/ssg/domain_specifics.yaml
+++ b/ssg/domain_specifics.yaml
@@ -76,6 +76,11 @@ programmes_festival_editions:
 active_industry_editions:
     - 12
 
+skip_build_for_models:
+    - industry-project
+    - industry-event
+    - industry-person
+
 article:
     poff.ee: POFFiArticle
     justfilm.ee: JustFilmiArticle

--- a/strapi/strapi-development/helpers/lifecycle_manager.js
+++ b/strapi/strapi-development/helpers/lifecycle_manager.js
@@ -15,12 +15,6 @@ const yaml = require('yaml')
 const path = require('path')
 const moment = require("moment-timezone")
 
-const domainSpecificsPath = path.join(__dirname, `/../../../ssg/domain_specifics.yaml`)
-const DOMAIN_SPECIFICS = yaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
-const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
-
-console.log();
-
 const mapping_domain = {
   'filmikool.poff.ee': 'filmikool',
   'hoff.ee': 'hoff',
@@ -280,6 +274,9 @@ async function modify_stapi_data(result, model_name, vanish = false) {
 }
 
 async function call_build(result, domains, model_name, del = false) {
+  const domainSpecificsPath = path.join(__dirname, `/../../../ssg/domain_specifics.yaml`)
+  const DOMAIN_SPECIFICS = yaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
+  const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
   // here to skip specific model builds
   if (MODELS_SKIP_BUILD.includes(model_name)) {
     return

--- a/strapi/strapi-development/helpers/lifecycle_manager.js
+++ b/strapi/strapi-development/helpers/lifecycle_manager.js
@@ -15,6 +15,12 @@ const yaml = require('yaml')
 const path = require('path')
 const moment = require("moment-timezone")
 
+const domainSpecificsPath = path.join(__dirname, `/../../../ssg/domain_specifics.yaml`)
+const DOMAIN_SPECIFICS = yaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
+const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
+
+console.log();
+
 const mapping_domain = {
   'filmikool.poff.ee': 'filmikool',
   'hoff.ee': 'hoff',
@@ -275,7 +281,7 @@ async function modify_stapi_data(result, model_name, vanish = false) {
 
 async function call_build(result, domains, model_name, del = false) {
   // here to skip specific model builds
-  if (model_name === 'industry-project' || model_name === 'industry-event' || model_name === 'industry-person') {
+  if (MODELS_SKIP_BUILD.includes(model_name)) {
     return
   }
   let build_error

--- a/strapi/strapi-development/helpers/lifecycle_manager.js
+++ b/strapi/strapi-development/helpers/lifecycle_manager.js
@@ -275,7 +275,7 @@ async function modify_stapi_data(result, model_name, vanish = false) {
 
 async function call_build(result, domains, model_name, del = false) {
   const domainSpecificsPath = path.join(__dirname, `/../../../ssg/domain_specifics.yaml`)
-  const DOMAIN_SPECIFICS = yaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
+  const DOMAIN_SPECIFICS = yaml.safeload(fs.readFileSync(domainSpecificsPath, 'utf8'))
   const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
   // here to skip specific model builds
   if (MODELS_SKIP_BUILD.includes(model_name)) {

--- a/strapi/strapi-development/helpers/lifecycle_manager.js
+++ b/strapi/strapi-development/helpers/lifecycle_manager.js
@@ -12,6 +12,7 @@ const {
 
 const fs = require('fs')
 const yaml = require('yaml')
+const jsyaml = require('js-yaml');
 const path = require('path')
 const moment = require("moment-timezone")
 
@@ -275,7 +276,7 @@ async function modify_stapi_data(result, model_name, vanish = false) {
 
 async function call_build(result, domains, model_name, del = false) {
   const domainSpecificsPath = path.join(__dirname, `/../../../ssg/domain_specifics.yaml`)
-  const DOMAIN_SPECIFICS = yaml.safeload(fs.readFileSync(domainSpecificsPath, 'utf8'))
+  const DOMAIN_SPECIFICS = jsyaml.load(fs.readFileSync(domainSpecificsPath, 'utf8'))
   const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
   // here to skip specific model builds
   if (MODELS_SKIP_BUILD.includes(model_name)) {

--- a/strapi/strapi-development/helpers/lifecycle_manager.js
+++ b/strapi/strapi-development/helpers/lifecycle_manager.js
@@ -280,6 +280,7 @@ async function call_build(result, domains, model_name, del = false) {
   const MODELS_SKIP_BUILD = DOMAIN_SPECIFICS.skip_build_for_models || []
   // here to skip specific model builds
   if (MODELS_SKIP_BUILD.includes(model_name)) {
+    console.log(`Skipping ${model_name} ${result.id} ${domains} build as per domain_specifics conf`)
     return
   }
   let build_error


### PR DESCRIPTION
ssg\domain_specifics.yaml

Under `skip_build_for_models` specify all Strapi model names to skip build for (for example: 
    - industry-project
    - industry-event
    - industry-person
).
Will work without restarting Strapi which is more convenient and reliable than current method.