### PR TITLE
Simplify-simplified-build - integrate "Remove non-essential from _fetchdir" to "Custom_build"

### DIFF
--- a/ssg/build_custom.sh
+++ b/ssg/build_custom.sh
@@ -46,31 +46,42 @@ ask_if_fetch()
     elif [ $new_number -lt 3 ] && [ $new_number -gt 0 ]
     then
         let fetch_number=$new_number
-        # ask_if_download_img $site_name $fetch_number
-        build $site_name $fetch_number
+        ask_if_simplify_build $site_name $fetch_number
+        # build $site_name $fetch_number
     else
         echo "Incorrect option, try again!"
         ask_if_fetch $site_name
     fi
 }
 
-# ask_if_download_img()
-# {
-#     printf '\n----------\nSelect: \n1 to download all images\n2 to not download all images\n0 to EXIT\n'
-#     read new_number
+ask_if_simplify_build()
+{
+    ANYDIRECTORIES=$(ls -ld ./source/_fetchdir/*/ 2> /dev/null)
 
-#     if [ $new_number -eq 0 ]
-#     then
-#         runexit
-#     elif [ $new_number -lt 3 ] && [ $new_number -gt 0 ]
-#     then
-#         let download_number=$new_number
-#         build $site_name $fetch_number $download_number
-#     else
-#         echo "Incorrect option, try again!"
-#         ask_if_download_img $site_name $fetch_number
-#     fi
-# }
+    if [ -z "$ANYDIRECTORIES" ] && [ $fetch_number -eq 2 ]; then
+        printf '\n----------\nPrevious build has already been simplified, continuing with simplified build\n'
+        printf 'For non-simplified full build you need to re-fetch data\n'
+        let simplify_build_number=1
+        build $site_name $fetch_number $simplify_build_number
+    else
+        :
+    fi
+
+    printf '\n----------\nSelect: \n1 To simplify build (skip building subpages [separate articles, cassettes, events etc]) \n2 To not simplify build\n0 to EXIT\n'
+    read new_number
+
+    if [ $new_number -eq 0 ]
+    then
+        runexit
+    elif [ $new_number -lt 3 ] && [ $new_number -gt 0 ]
+    then
+        let simplify_build_number=$new_number
+        build $site_name $fetch_number $simplify_build_number
+    else
+        echo "Incorrect option, try again!"
+        ask_if_simplify_build $site_name $fetch_number
+    fi
+}
 
 build()
 {
@@ -85,12 +96,6 @@ build()
         printf "\nStarting to fetch new data:\n"
         fetch_data
     fi
-
-    # if [ $download_number -eq 1 ]
-    # then
-    #     printf "\nStarting to download new images:\n"
-    #     download_img
-    # fi
 
     if [ $site_name ]
     then
@@ -120,6 +125,13 @@ build()
         printf '\n----------                  Adding ignore paths                ----------\n\n'
         node ./helpers/add_config_ignorePaths.js
         printf '\n----------               Finished adding ignore paths            ----------\n'
+
+
+        if [ $simplify_build_number -eq 1 ]
+        then
+            printf "\nSimplifying build:\n"
+            simplify_build
+        fi
 
         node ./node_modules/entu-ssg/src/build.js ./entu-ssg.yaml full
 
@@ -231,27 +243,10 @@ fetch_data()
 
 }
 
-# download_img()
-# {
-#     [ -d "build/assets" ] && rm -r build/*
-#     [ ! -d "build/assets" ] && mkdir -p build/assets
-#     [ -d "assets/img/dynamic" ] && rm -r assets/img/dynamic/*
-
-#     printf '\n----------         Downloading all img from Strapi         ----------\n\n'
-#     node ./helpers/download_article_img.js
-#     node ./helpers/download_footer_img.js
-#     node ./helpers/download_teams_img.js
-#     node ./helpers/download_cassette_films_credentials_img.js
-#     node ./helpers/download_organisations_img.js
-#     # node ./helpers/download_persons_img.js
-#     node ./helpers/download_trioblock_img.js
-#     node ./helpers/download_supporters_page_img.js
-#     node ./helpers/download_programmes_img.js
-#     node ./helpers/download_shops_img.js
-#     node ./helpers/download_industry_person_img.js
-#     node ./helpers/download_industry_project_img.js
-#     # node ./helpers/download_casettes_and_films_img.js
-#     printf '\n\n----------     Finished downloading all img from Strapi    ----------\n\n'
-# }
+simplify_build()
+{
+    echo 'Simplified build...'
+    rm -rf ./source/_fetchdir/*/
+}
 
 ask_what_to_build


### PR DESCRIPTION
Enamik vist meist juba kasutab lokaalselt ehitades õigesti ajastatult "Remove non-essential from _fetchdir" võimalust juhul mil reaalselt pole vaja antud hetkel kogu mudru ehitada. Näiteks on vaja tuunida kõikide filmide/screeningute/eventide otsingut, aga konkreetseid filmide/screeningute/eventide lehti vaadata antud hetk localis plaanis pole. St lühendab buildi aega ca 20-45 minutilt ca 5 minuti pikkuseks. 

Ma heameelega sunniks selle mu custom_build scripti kasutajatele peale ja teeks lihtsamaks (endale ka, sest ma usun, et kasutan kõige rohkem). Näidiseks: 
Industry build... 3min 50sek - Sobib eriti hästi kui soov justnimelt eile jutuks olnud industry-events-search lehte tuunida ja üksikuid evente/kassette jms pole plaanis lahti klikkida (simplified buildi puhul saab neil 404 - sest neid ei ehitata ajavõidu mõttes).

Tööpõhimõte on sama mis "Remove non-essential from _fetchdir" scriptil - kustutab kõik kataloogid kaustast ssg/source/_fetchdir mida võib ENTU buildi ajal teha ka näiteks käsitsi ja jätta alles väljavalitud (nt ise jätan paar valitud kassetti kui kasseti-template tuuning käsil). Lihtsalt õige ajastus annab õige tulemuse ja seetõttu ma ta custom_buildi lisada sooviks.

![image (5)](https://user-images.githubusercontent.com/68708892/141874498-f0a74c75-c0bc-4c2b-b78e-e7a686bbf2bc.png)
![image](https://user-images.githubusercontent.com/68708892/141874581-c7f2205d-feb9-40ad-a90f-f325b8718cdd.png)
![image (6)](https://user-images.githubusercontent.com/68708892/141874510-056b8baf-a4fa-47da-947a-b1f1a60833ef.png)