### PR TITLE
#470   events build by domain

### DIFF
--- a/strapi/strapi-development/extensions/content-manager/admin/src/utils/getBuildEstimateDuration.js
+++ b/strapi/strapi-development/extensions/content-manager/admin/src/utils/getBuildEstimateDuration.js
@@ -1,4 +1,5 @@
-const strapiHost = `${CUSTOM_VARIABLES['StrapiProtocol']}://${CUSTOM_VARIABLES['StrapiHost']}`
+const strapiPortString = CUSTOM_VARIABLES['StrapiProtocol'] === 'https' ? `` : `:${CUSTOM_VARIABLES['StrapiPort']}`
+const strapiHost = `${CUSTOM_VARIABLES['StrapiProtocol']}://${CUSTOM_VARIABLES['StrapiHost']}${strapiPortString}`
 
 const getBuildEstimateDuration = async (buildArgs) => {
 


### PR DESCRIPTION
- Eventi domeenid võetakse seotud course alt (kui on), st päritakse lifecycles course info. Vastavalt käivitatakse buildid.
- Localhostis Strapi estimate build duration notificationid parandatud.